### PR TITLE
Fall back to link children if no text provided

### DIFF
--- a/components/link.js
+++ b/components/link.js
@@ -13,7 +13,7 @@ class Link extends IdyllComponent {
     }
     return (
       <a {...props}>
-        {this.props.text}
+        {this.props.text || this.props.children}
       </a>
     );
   }


### PR DESCRIPTION
This PR modifies `link` to render `this.props.text || this.props.children` instead of just `this.props.text`. That allows the syntax `[link]test[/link] instead of just `[link text:"test"/]`, which is a bit more flexible in terms of allowing spans and images inside `a` tags.