### PR TITLE
Fix equation spacing

### DIFF
--- a/components/equation.js
+++ b/components/equation.js
@@ -103,9 +103,14 @@ class Equation extends IdyllComponent {
     const latexChar = '$';
     const latexString = latexChar + this.getLatex()  + latexChar;
 
-    const style = Object.assign({
-      display: this.props.display ? "block" : "inline-block"
-    }, this.props.style);
+    let style;
+    if (this.state.showRange) {
+      style = this.props.style;
+    } else {
+      style = Object.assign({
+        display: this.props.display ? "block" : "inline-block"
+      }, this.props.style);
+    }
 
     return (
       <span style={style}>

--- a/components/equation.js
+++ b/components/equation.js
@@ -102,8 +102,13 @@ class Equation extends IdyllComponent {
   render() {
     const latexChar = '$';
     const latexString = latexChar + this.getLatex()  + latexChar;
+
+    const style = Object.assign({
+      display: this.props.display ? "block" : "inline-block"
+    }, this.props.style);
+
     return (
-      <span>
+      <span style={style}>
           <Latex displayMode={this.props.display}>{latexString}</Latex>
           {this.renderEditing()}
       </span>


### PR DESCRIPTION
This PR fixes post-equation whitespace as following:

- The container span for inline equations gets `display: inline-block` when not in `showRange` mode. The katex equation itself already has inline-block so this doesn't seem to change the vertical alignment
- The container span for display equations gets `display: block` when not in `showRange` mode, though this could probably be removed since it has no effect

