### PR TITLE
Add codepen component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,6 @@ jspm_packages
 .node_repl_history
 
 *.js
+!components/**/*.js
 !scripts/*
 !index.js

--- a/components/codepen.js
+++ b/components/codepen.js
@@ -1,4 +1,18 @@
 const React = require('react');
 const ReactCodepen = require('react-codepen');
+const IdyllComponent = require('idyll-component');
+
+class Codepen extends IdyllComponent {
+  render () {
+    return <ReactCodepen
+      user={this.props.user}
+      hash={this.props.hash}
+      width={this.props.width}
+      height={this.props.height}
+      tab={this.props.tab}
+      theme={this.props.theme}
+    />;
+  }
+}
 
 module.exports = ReactCodepen;

--- a/components/codepen.js
+++ b/components/codepen.js
@@ -1,0 +1,4 @@
+const React = require('react');
+const ReactCodepen = require('react-codepen');
+
+module.exports = ReactCodepen;

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ module.exports = {
   boolean: require('./components/boolean.js'),
   button: require('./components/button.js'),
   chart: require('./components/chart.js'),
+  codepen: require('./components/codepen.js'),
   'display-var': require('./components/display-var.js'),
   dynamic: require('./components/dynamic.js'),
   equation: require('./components/equation.js'),

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "babel-cli": "6.24.1",
     "enzyme": "^2.8.2",
     "jest": "^19.0.2",
-    "react-addons-test-utils": "^15.5.1"
+    "react-addons-test-utils": "^15.5.1",
+    "react-codepen": "^0.1.0"
   }
 }


### PR DESCRIPTION
This PR adds a codepen component, which just transparently idyll-wraps the [react-codepen](https://github.com/jasonbellamy/react-codepen) component. It seems to work fine with no extra knobs needed.

At [seriously only a few lines of code](https://github.com/jasonbellamy/react-codepen/blob/master/src/react-codepen.js), this seems trivial enough to be a reasonable fit for default-components. Not 100% sure where the line is drawn between default components and separately-required components though.

This code:

```
[Codepen user:"rsreusser" hash:"YVRXzy"/]
```

renders like this:

<img width="714" alt="screen shot 2017-05-29 at 16 49 44" src="https://cloud.githubusercontent.com/assets/572717/26561909/0e477202-4490-11e7-840d-db7bba4a37da.png">

