### PR TITLE
Check for document when using equations

### DIFF
--- a/components/equation.js
+++ b/components/equation.js
@@ -5,7 +5,9 @@ const Latex = require('react-latex');
 const select = require('d3-selection').select;
 const format = require('d3-format').format;
 
-document.write('<link href="//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.3.0/katex.min.css" rel="stylesheet">');
+if (typeof document !== 'undefined') {
+  document.write('<link href="//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.3.0/katex.min.css" rel="stylesheet">');
+}
 
 const allowedProps = ['domain', 'step', 'children'];
 


### PR DESCRIPTION
This PR checks when important equations to see if `document` is defined. If not, then it can't insert css link tag anyway, so it skips it. Otherwise this seems to lead to a SSR error that document is not defined.