### PR TITLE
Move analytics js to componentDidMount for SSR

### DIFF
--- a/components/analytics.js
+++ b/components/analytics.js
@@ -2,17 +2,14 @@ const React = require('react');
 const IdyllComponent = require('idyll-component');
 
 class Analytics extends IdyllComponent {
-  constructor(props) {
-    super(props);
+  componentDidMount() {
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
     ga('create', props.google, 'auto');
-  }
 
-  componentDidMount() {
     window.ga('send', 'pageview', {
       tag: this.props.tag
     });


### PR DESCRIPTION
Analytics breaks SSR because the window element isn't defined on the server. This PR just moves everything to `componentDidMount`, which I *think* makes sense? Or could check if window is defined in the constructor. I have no strong preference.