### PR TITLE
use aside-container instead of relative

### DIFF
--- a/components/aside.js
+++ b/components/aside.js
@@ -4,7 +4,7 @@ const IdyllComponent = require('idyll-component');
 class Aside extends IdyllComponent {
   render() {
     return (
-      <div className={'relative'}>
+      <div className={'aside-container'}>
         <div className={'aside'}>
           {this.props.children}
         </div>


### PR DESCRIPTION
this makes more sense as some layouts won't necessarily want the container to be display relative 